### PR TITLE
Update Chris Swierczewski's contact info

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ pychebfun is hosted at http://github.com/pychebfun/pychebfun.
 
 [1]: https://github.com/olivierverdier
 [2]: http://www2.maths.ox.ac.uk/chebfun/
-[3]: mailto:cswiercz@amath.washington.edu
+[3]: https://github.com/cswiercz
 [4]: https://github.com/pychebfun/pychebfun/tree/master/examples
 [5]: https://github.com/pychebfun/pychebfun/tree/master/examples/extrema.py
 


### PR DESCRIPTION
Chris's GitHub profile is the preferred contact method as opposed to his University of Washington email address. (Which will expire in a few months.)

_Thank you, Oliver, for keeping me listed as a contributor to your project! It's a nice resume entry, even though I contributed very little compared to you._
